### PR TITLE
fix: resolve critical/high audit issues and sortable-list snap-back

### DIFF
--- a/src/lib/audio-store.svelte.ts
+++ b/src/lib/audio-store.svelte.ts
@@ -303,7 +303,11 @@ class AudioStore {
 	shuffle(): void {
 		if (!this.queue.length || this.queue.length < 2 || !this.currentTrack) return;
 		const rest = this.queue.filter((_, i) => i !== this.currentQueueIndex);
-		const shuffled = rest.sort(() => Math.random() - 0.5);
+		const shuffled = [...rest];
+		for (let i = shuffled.length - 1; i > 0; i--) {
+			const j = Math.floor(Math.random() * (i + 1));
+			[shuffled[i], shuffled[j]] = [shuffled[j]!, shuffled[i]!];
+		}
 		this.queue = [this.currentTrack, ...shuffled];
 		this.currentQueueIndex = 0;
 		this.shuffleEnabled = true;

--- a/src/lib/audio-store.svelte.ts
+++ b/src/lib/audio-store.svelte.ts
@@ -92,6 +92,9 @@ class AudioStore {
 			if (d.currentTime !== undefined) this.currentTime = d.currentTime;
 			if (d.insertMode !== undefined) this.insertMode = d.insertMode;
 			if (d.currentQueueIndex !== undefined) this.currentQueueIndex = d.currentQueueIndex;
+			if (this.duration > 0) {
+				this.progress = (this.currentTime / this.duration) * 100;
+			}
 		} catch {
 			/* ignore */
 		}

--- a/src/lib/components/ui/audio/elements/fader/fader.svelte
+++ b/src/lib/components/ui/audio/elements/fader/fader.svelte
@@ -36,48 +36,22 @@
 	const isVertical = $derived(orientation === "vertical");
 	const fillPercent = $derived(((value - min) / (max - min)) * 100);
 
-	// ── Track dimensions ────────────────────────────────────────────────────────
-	const trackSize = $derived.by<Record<Size, string>>(() => ({
-		sm: isVertical ? "w-2" : "h-2",
-		default: isVertical ? "w-3" : "h-3",
-		lg: isVertical ? "w-4" : "h-4",
-	}));
+	// ── Static lookup maps (created once, never re-allocated) ───────────────────
+	const TRACK = { v: { sm: "w-2", default: "w-3", lg: "w-4" }, h: { sm: "h-2", default: "h-3", lg: "h-4" } };
+	const TW = { v: { sm: "w-7", default: "w-9", lg: "w-11" }, h: { sm: "w-4", default: "w-5", lg: "w-6" } };
+	const TH = { v: { sm: "h-4", default: "h-5", lg: "h-6" }, h: { sm: "h-7", default: "h-9", lg: "h-11" } };
+	const TW_S = { v: { sm: "28px", default: "36px", lg: "44px" }, h: { sm: "16px", default: "20px", lg: "24px" } };
+	const TH_S = { v: { sm: "16px", default: "20px", lg: "24px" }, h: { sm: "28px", default: "36px", lg: "44px" } };
+	const MW = { v: { sm: "w-3", default: "w-4", lg: "w-5" }, h: { sm: "w-px", default: "w-px", lg: "w-px" } };
+	const MH = { v: { sm: "h-px", default: "h-px", lg: "h-px" }, h: { sm: "h-3", default: "h-4", lg: "h-5" } };
 
-	// ── Thumb dimensions ────────────────────────────────────────────────────────
-	const thumbW = $derived.by<Record<Size, string>>(() => ({
-		sm: isVertical ? "w-7" : "w-4",
-		default: isVertical ? "w-9" : "w-5",
-		lg: isVertical ? "w-11" : "w-6",
-	}));
-	const thumbH = $derived.by<Record<Size, string>>(() => ({
-		sm: isVertical ? "h-4" : "h-7",
-		default: isVertical ? "h-5" : "h-9",
-		lg: isVertical ? "h-6" : "h-11",
-	}));
-
-	const thumbWStyles = $derived.by<Record<Size, string>>(() => ({
-		sm: isVertical ? "28px" : "16px",
-		default: isVertical ? "36px" : "20px",
-		lg: isVertical ? "44px" : "24px",
-	}));
-	const thumbHStyles = $derived.by<Record<Size, string>>(() => ({
-		sm: isVertical ? "16px" : "28px",
-		default: isVertical ? "20px" : "36px",
-		lg: isVertical ? "24px" : "44px",
-	}));
-	const cssVars = $derived(`--thumb-w: ${thumbWStyles[size]}; --thumb-h: ${thumbHStyles[size]};`);
-
-	// ── Thumb mark dimensions ───────────────────────────────────────────────────
-	const markW = $derived.by<Record<Size, string>>(() => ({
-		sm: isVertical ? "w-3" : "w-px",
-		default: isVertical ? "w-4" : "w-px",
-		lg: isVertical ? "w-5" : "w-px",
-	}));
-	const markH = $derived.by<Record<Size, string>>(() => ({
-		sm: isVertical ? "h-px" : "h-3",
-		default: isVertical ? "h-px" : "h-4",
-		lg: isVertical ? "h-px" : "h-5",
-	}));
+	const axis = $derived(isVertical ? "v" : "h");
+	const trackSize = $derived(TRACK[axis][size]);
+	const thumbW = $derived(TW[axis][size]);
+	const thumbH = $derived(TH[axis][size]);
+	const markW = $derived(MW[axis][size]);
+	const markH = $derived(MH[axis][size]);
+	const cssVars = $derived(`--thumb-w: ${TW_S[axis][size]}; --thumb-h: ${TH_S[axis][size]};`);
 
 	// ── Thumb position as CSS ───────────────────────────────────────────────────
 	// Vertical: thumb slides from bottom (0%) to top (100%)

--- a/src/lib/components/ui/audio/elements/wave/wave.svelte
+++ b/src/lib/components/ui/audio/elements/wave/wave.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	interface Props {
+		class?: string;
+	}
+
+	let { class: className = "" }: Props = $props();
+</script>
+
+<div class="flex items-center justify-center rounded-md border border-dashed p-8 {className}">
+	<span class="text-muted-foreground text-sm">Wave Component</span>
+</div>

--- a/src/lib/components/ui/audio/player/audio-player-volume.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-volume.svelte
@@ -26,7 +26,8 @@
 
 	const tooltipLabel = $derived(audioStore.isMuted ? "Muted" : `Volume ${volumePercent}%`);
 
-	function handleSliderChange(v: number) {
+	function handleSliderChange(values: number[]) {
+		const v = values[0];
 		if (v === undefined) return;
 		audioStore.setVolume({ volume: v / 100 });
 		if (v === 0 && !audioStore.isMuted) audioStore.toggleMute();
@@ -83,9 +84,7 @@
 				max={100}
 				min={0}
 				bind:value={volumePercent}
-				onValueChange={(e) => {
-					handleSliderChange(e);
-				}}
+				onValueChange={handleSliderChange}
 			/>
 
 			<Volume2 aria-hidden="true" class="size-4 shrink-0 opacity-60" />

--- a/src/lib/components/ui/audio/provider/audio-provider.svelte
+++ b/src/lib/components/ui/audio/provider/audio-provider.svelte
@@ -24,6 +24,7 @@
 	let lastSeekTime = 0;
 	let lastUpdateTime = 0;
 	let prevTrackId: string | number | undefined = undefined;
+	let isRestoring = false;
 
 	// ─── Sync tracks prop → store ───────────────────────────────────────────────
 	$effect(() => {
@@ -264,6 +265,7 @@
 		// ── Restore persisted state ───────────────────────────────────────────────
 		(async () => {
 			if (!audioStore.currentTrack || audioStore.currentTime <= 0) return;
+			isRestoring = true;
 			const track = audioStore.currentTrack;
 			const audioDur = audio.duration || audioStore.duration || 0;
 			const isLive = htmlAudio.isLive(audioDur);
@@ -283,6 +285,8 @@
 				audioStore.isPlaying = false;
 				audioStore.isLoading = false;
 				audioStore.isBuffering = false;
+			} finally {
+				isRestoring = false;
 			}
 		})();
 
@@ -305,6 +309,7 @@
 
 	/** Load new track and play when currentTrack changes */
 	$effect(() => {
+		if (isRestoring) return;
 		const track = audioStore.currentTrack;
 		const trackId = track?.id;
 		if (!track || trackId === prevTrackId) return;

--- a/src/lib/components/ui/audio/provider/audio-provider.svelte
+++ b/src/lib/components/ui/audio/provider/audio-provider.svelte
@@ -25,6 +25,7 @@
 	let lastUpdateTime = 0;
 	let prevTrackId: string | number | undefined = undefined;
 	let isRestoring = false;
+	let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	// ─── Sync tracks prop → store ───────────────────────────────────────────────
 	$effect(() => {
@@ -293,6 +294,10 @@
 		return () => {
 			ctrl.abort();
 			htmlAudio.removeEventListener("bufferUpdate", handleBufferUpdate);
+			if (saveTimeout) {
+				clearTimeout(saveTimeout);
+				saveTimeout = null;
+			}
 			if (preloadAudio) {
 				preloadAudio.src = "";
 				preloadAudio = null;
@@ -360,9 +365,8 @@
 		if (qLen === 0 && preloadAudio) preloadAudio.src = "";
 	});
 
-	/** Persist state to localStorage */
+	/** Persist state to localStorage (debounced; currentTime excluded from reactivity) */
 	$effect(() => {
-		// Accessing each field registers it as a dependency
 		void [
 			audioStore.currentTrack,
 			audioStore.queue.length,
@@ -371,11 +375,11 @@
 			audioStore.playbackRate,
 			audioStore.repeatMode,
 			audioStore.shuffleEnabled,
-			audioStore.currentTime,
 			audioStore.insertMode,
 			audioStore.currentQueueIndex,
 		];
-		audioStore.saveToStorage();
+		if (saveTimeout) clearTimeout(saveTimeout);
+		saveTimeout = setTimeout(() => audioStore.saveToStorage(), 1000);
 	});
 </script>
 

--- a/src/lib/user-config.svelte.ts
+++ b/src/lib/user-config.svelte.ts
@@ -64,7 +64,13 @@ export function parseUserConfig(cookie: string): UserConfigType {
 	const cookieMap = parseCookie(cookie);
 	const userConfig = cookieMap[USER_CONFIG_COOKIE_NAME];
 	if (!userConfig) return userConfigSchema.parse({});
-	return userConfigSchema.parse(JSON.parse(userConfig));
+	try {
+		const parsed = JSON.parse(userConfig);
+		const result = userConfigSchema.safeParse(parsed);
+		return result.success ? result.data : userConfigSchema.parse({});
+	} catch {
+		return userConfigSchema.parse({});
+	}
 }
 
 export class UserConfig {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -5,8 +5,16 @@ export const load: LayoutServerLoad = async ({ cookies }) => {
 	const sidebarState = cookies.get("sidebar_state") === "true" ? true : false;
 
 	const userConfigCookie = cookies.get(USER_CONFIG_COOKIE_NAME);
-	const parsedUserConfig = userConfigCookie ? JSON.parse(userConfigCookie) : {};
-	const userConfig = userConfigSchema.parse(parsedUserConfig);
+	let parsedUserConfig = {};
+	if (userConfigCookie) {
+		try {
+			parsedUserConfig = JSON.parse(userConfigCookie);
+		} catch {
+			/* ignore malformed cookie JSON */
+		}
+	}
+	const userConfigResult = userConfigSchema.safeParse(parsedUserConfig);
+	const userConfig = userConfigResult.success ? userConfigResult.data : userConfigSchema.parse({});
 
 	return { sidebarState, userConfig };
 };


### PR DESCRIPTION
## Summary
- Fixes #30-#37 critical and high severity audit issues
- Fixes sortable-list snap-back caused by provider feedback loop

## Changes
### Critical fixes
- **#33**: Safe cookie/Zod parsing to prevent 500 errors from malformed cookies
- **#32**: Added placeholder wave.svelte component
- **#31**: Prevent race condition between restore-state and track-change effects
- **#30**: Debounced localStorage writes, excluded currentTime from reactive deps

### High fixes
- **#37**: Replaced $derived.by overuse in fader with static lookup maps
- **#36**: Recompute progress after state restore from localStorage
- **#35**: Fixed volume slider NaN from array-to-number mismatch
- **#34**: Replaced biased sort shuffle with Fisher-Yates algorithm

### Other fixes
- Sortable-list snap-back: AudioProvider tracks sync effect now uses `untrack()` to avoid overwriting user-initiated queue reorders
- Sortable-list: replaced `requestAnimationFrame` with `await tick()` for reliable isDragging gating
- Audio queue styling fix