### PR TITLE
fix: resolve sortable-list snap-back — provider feedback loop and tick() gating

### DIFF
--- a/src/lib/components/ui/audio/elements/sortable-list/sortable-list.svelte
+++ b/src/lib/components/ui/audio/elements/sortable-list/sortable-list.svelte
@@ -1,4 +1,5 @@
 <script lang="ts" generics="Item extends { id: string | number }">
+	import { tick } from "svelte";
 	import { flip } from "svelte/animate";
 	import { cn } from "$lib/utils.js";
 	import type { Snippet } from "svelte";
@@ -15,20 +16,11 @@
 
 	const flipDurationMs = 150;
 
-	// Internal DnD state — completely decoupled from the `items` prop.
-	// The prop only flows in; results flow out via onDrop.
 	let isDragging = $state(false);
 	let dndItems = $state<Item[]>([...items]);
-	let dragTimeout: ReturnType<typeof requestAnimationFrame> | undefined;
 
-	// Sync prop → dndItems only when the user is NOT mid-drag.
-	// During a drag svelte-dnd-action owns the list (shadow items, order),
-	// so external reactive updates must not overwrite its internal state.
 	$effect(() => {
 		if (isDragging) return;
-		// Only sync when the prop order actually differs from internal state.
-		// This prevents overwriting the just-dropped order before the parent's
-		// state update has propagated back down through the items prop.
 		const needsSync =
 			dndItems.length !== items.length ||
 			dndItems.some((item, i) => item.id !== items[i]?.id);
@@ -38,35 +30,19 @@
 	});
 
 	function handleConsider(e: CustomEvent<{ items: Item[] }>) {
-		if (dragTimeout !== undefined) {
-			cancelAnimationFrame(dragTimeout);
-			dragTimeout = undefined;
-		}
 		isDragging = true;
-		// Only update the internal DnD list — never write back to the prop.
-		// Writing to the prop would trigger the parent's $effect.pre which strips
-		// the shadow-item markers, causing svelte-dnd-action to lose its DOM
-		// reference and crash in keepOriginalElementInDom.
 		dndItems = e.detail.items;
 	}
 
-	function handleFinalize(e: CustomEvent<{ items: Item[] }>) {
-		// Strip any lingering shadow placeholder items before we publish the result.
+	async function handleFinalize(e: CustomEvent<{ items: Item[] }>) {
 		const finalItems = e.detail.items.filter(
 			(i: any) => !i[SHADOW_ITEM_MARKER_PROPERTY_NAME]
 		) as Item[];
 		dndItems = finalItems;
 		onDrop?.(finalItems);
 
-		// Defer clearing isDragging until the next animation frame so the
-		// parent has time to propagate its state update back down through
-		// the items prop. Without this delay the $effect above can run with
-		// the old items array and visually snap the list back to its
-		// previous order.
-		dragTimeout = requestAnimationFrame(() => {
-			isDragging = false;
-			dragTimeout = undefined;
-		});
+		await tick();
+		isDragging = false;
 	}
 </script>
 

--- a/src/lib/components/ui/audio/provider/audio-provider.svelte
+++ b/src/lib/components/ui/audio/provider/audio-provider.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from "svelte";
+	import { onMount, untrack } from "svelte";
 	import type { Snippet } from "svelte";
 	import { htmlAudio } from "$lib/html-audio.js";
 	import type { Track } from "$lib/html-audio.js";
@@ -29,16 +29,18 @@
 
 	// ─── Sync tracks prop → store ───────────────────────────────────────────────
 	$effect(() => {
-		if (!tracks || tracks.length === 0) return;
-		const q = audioStore.queue;
+		const t = tracks;
+		if (!t || t.length === 0) return;
+		const q = untrack(() => audioStore.queue);
+		const cqi = untrack(() => audioStore.currentQueueIndex);
 		const changed =
 			q.length === 0 ||
-			q.length !== tracks.length ||
-			q.some((t, i) => t.id !== tracks[i]?.id);
+			q.length !== t.length ||
+			q.some((track, i) => track.id !== t[i]?.id);
 		if (changed) {
-			audioStore.queue = tracks;
-			if (!audioStore.currentTrack) audioStore.currentTrack = tracks[0] ?? null;
-			if (audioStore.currentQueueIndex === -1) audioStore.currentQueueIndex = 0;
+			audioStore.queue = [...t];
+			if (!untrack(() => audioStore.currentTrack)) audioStore.currentTrack = t[0] ?? null;
+			if (cqi === -1) audioStore.currentQueueIndex = 0;
 		}
 	});
 

--- a/src/lib/components/ui/audio/queue/audio-queue.svelte
+++ b/src/lib/components/ui/audio/queue/audio-queue.svelte
@@ -121,7 +121,7 @@
 		</div>
 
 		<!-- Track list ────────────────────────────────────────────────────────── -->
-		<div class="max-h-[60vh] min-h-[200px] overflow-hidden px-2 py-2 pb-12">
+		<div class="max-h-[60vh] min-h-50 overflow-hidden px-2 py-2 pb-12">
 			<AudioTrackList
 				filterQuery={searchQuery}
 				sortable={!isFiltered}


### PR DESCRIPTION
## Summary
Fixes the sortable-list snap-back when reordering tracks in the audio queue.

## Root Cause
1. **AudioProvider feedback loop**: The tracks sync `$effect` in `audio-provider.svelte` read `audioStore.queue` as a reactive dependency. When the user reordered the queue, the updated queue triggered this effect, which compared it to the still-original `tracks` prop and overwrote the queue back to original order.
2. **SortableList timing**: `requestAnimationFrame` for deferring `isDragging = false` was unreliable — parent reactive state may not propagate before the rAF callback fires.

## Fixes
- Wrapped `audioStore` reads in `untrack()` so the provider effect only reacts to `tracks` prop changes, not internal queue mutations
- Replaced `requestAnimationFrame` with `await tick()` for reliable parent→child prop propagation gating
- Adjusted audio queue `min-h` styling