### PR TITLE
refactor: replace singleton with context-based audio store

### DIFF
--- a/src/lib/audio-store.svelte.ts
+++ b/src/lib/audio-store.svelte.ts
@@ -53,10 +53,11 @@ export function calculatePreviousIndex(params: QueueNavigationParams): number {
 
 // ─── Store ───────────────────────────────────────────────────────────────────
 
-const STORAGE_KEY = "audio:ui:store";
+const DEFAULT_STORAGE_KEY = "audio:ui:store";
 
 export class AudioStore {
 	readonly htmlAudio: HtmlAudio;
+	private readonly storageKey: string | null;
 
 	// ── Reactive state ──────────────────────────────────────────────────────
 	currentTrack: Track | null = $state(null);
@@ -83,16 +84,18 @@ export class AudioStore {
 		return this.htmlAudio.isLive(this.duration);
 	}
 
-	constructor(htmlAudio: HtmlAudio) {
+	constructor(htmlAudio: HtmlAudio, storageKey?: string | null) {
 		this.htmlAudio = htmlAudio;
-		if (canUseDOM()) this.loadFromStorage();
+		this.storageKey = storageKey === undefined ? DEFAULT_STORAGE_KEY : storageKey;
+		if (canUseDOM() && this.storageKey) this.loadFromStorage();
 	}
 
 	// ── Persistence ─────────────────────────────────────────────────────────
 
 	loadFromStorage(): void {
+		if (!this.storageKey) return;
 		try {
-			const raw = localStorage.getItem(STORAGE_KEY);
+			const raw = localStorage.getItem(this.storageKey);
 			if (!raw) return;
 			const d = JSON.parse(raw);
 			if (d.currentTrack !== undefined) this.currentTrack = d.currentTrack;
@@ -114,10 +117,10 @@ export class AudioStore {
 	}
 
 	saveToStorage(): void {
-		if (!canUseDOM()) return;
+		if (!canUseDOM() || !this.storageKey) return;
 		try {
 			localStorage.setItem(
-				STORAGE_KEY,
+				this.storageKey,
 				JSON.stringify({
 					currentTrack: this.currentTrack,
 					queue: this.queue,

--- a/src/lib/audio-store.svelte.ts
+++ b/src/lib/audio-store.svelte.ts
@@ -71,6 +71,11 @@ class AudioStore {
 	errorMessage: string | null = $state(null);
 	currentQueueIndex = $state(-1);
 
+	// ── Derived ─────────────────────────────────────────────────────────────
+	get isLive(): boolean {
+		return htmlAudio.isLive(this.duration);
+	}
+
 	constructor() {
 		if (canUseDOM()) this.loadFromStorage();
 	}

--- a/src/lib/audio-store.svelte.ts
+++ b/src/lib/audio-store.svelte.ts
@@ -1,7 +1,12 @@
-import { htmlAudio, type Track } from "$lib/html-audio.js";
+import { createContext } from "svelte";
+import { type HtmlAudio, type Track } from "$lib/html-audio.js";
 
 export type RepeatMode = "none" | "one" | "all";
 export type InsertMode = "first" | "last" | "after";
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+export const [getAudioContext, setAudioContext] = createContext<AudioStore>();
 
 // ─── Helper functions ────────────────────────────────────────────────────────
 
@@ -50,7 +55,9 @@ export function calculatePreviousIndex(params: QueueNavigationParams): number {
 
 const STORAGE_KEY = "audio:ui:store";
 
-class AudioStore {
+export class AudioStore {
+	readonly htmlAudio: HtmlAudio;
+
 	// ── Reactive state ──────────────────────────────────────────────────────
 	currentTrack: Track | null = $state(null);
 	queue: Track[] = $state([]);
@@ -73,10 +80,11 @@ class AudioStore {
 
 	// ── Derived ─────────────────────────────────────────────────────────────
 	get isLive(): boolean {
-		return htmlAudio.isLive(this.duration);
+		return this.htmlAudio.isLive(this.duration);
 	}
 
-	constructor() {
+	constructor(htmlAudio: HtmlAudio) {
+		this.htmlAudio = htmlAudio;
 		if (canUseDOM()) this.loadFromStorage();
 	}
 
@@ -133,12 +141,12 @@ class AudioStore {
 	play(): void {
 		if (this.isLoading) return;
 		this.isPlaying = true;
-		htmlAudio.play().catch(() => {});
+		this.htmlAudio.play().catch(() => {});
 	}
 
 	pause(): void {
 		this.isPlaying = false;
-		htmlAudio.pause();
+		this.htmlAudio.pause();
 	}
 
 	togglePlay(): void {
@@ -288,7 +296,7 @@ class AudioStore {
 	}
 
 	setPlaybackRate(rate: number): void {
-		if (this.duration && htmlAudio.isLive(this.duration)) return;
+		if (this.duration && this.htmlAudio.isLive(this.duration)) return;
 		this.playbackRate = Math.max(0.25, Math.min(2, rate));
 	}
 
@@ -371,7 +379,7 @@ class AudioStore {
 	loadAndPlayTrack(track: Track, queueIndex: number): void {
 		const isLiveStream =
 			track.live === true ||
-			(track.duration !== undefined && htmlAudio.isLive(track.duration));
+			(track.duration !== undefined && this.htmlAudio.isLive(track.duration));
 
 		this.currentTrack = track;
 		this.currentQueueIndex = queueIndex;
@@ -386,5 +394,3 @@ class AudioStore {
 		this.isPlaying = true;
 	}
 }
-
-export const audioStore = new AudioStore();

--- a/src/lib/components/ui/audio/elements/waveform/waveform.svelte
+++ b/src/lib/components/ui/audio/elements/waveform/waveform.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { onMount, tick } from "svelte";
 	import WaveSurfer from "wavesurfer.js";
-	import { audioStore } from "$lib/audio-store.svelte.js";
-	import { htmlAudio } from "$lib/html-audio.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		/** Pre-decoded peaks array (0–1). If omitted, wavesurfer decodes from URL. */
@@ -63,8 +64,8 @@
 	onMount(() => {
 		if (!containerEl) return;
 
-		htmlAudio.init();
-		const audioEl = htmlAudio.getAudioElement();
+		audioStore.htmlAudio.init();
+		const audioEl = audioStore.htmlAudio.getAudioElement();
 		if (!audioEl) return;
 
 		wavesurfer = WaveSurfer.create({
@@ -120,7 +121,7 @@
 		// Skip waveform generation for live streams to prevent AbortErrors,
 		// UNLESS the user explicitly bypassed this by providing manual peaks data.
 		const trackDuration = audioStore.currentTrack.duration ?? audioStore.duration;
-		const isLive = audioStore.currentTrack.live || htmlAudio.isLive(trackDuration);
+		const isLive = audioStore.currentTrack.live || audioStore.htmlAudio.isLive(trackDuration);
 		const hasPeaks = peaks && peaks.length > 0;
 		if (isLive && !hasPeaks) {
 			isReady = true;
@@ -179,7 +180,7 @@
 
 	// Live stream: disable interaction, but allow showing if peaks are manually provided
 	const isLiveStream = $derived(
-		htmlAudio.isLive(audioStore.duration) || audioStore.currentTrack?.live
+		audioStore.htmlAudio.isLive(audioStore.duration) || audioStore.currentTrack?.live
 	);
 	const showLivestreamFallback = $derived(isLiveStream && !(peaks && peaks.length > 0));
 

--- a/src/lib/components/ui/audio/examples/fader-volume-control-demo.svelte
+++ b/src/lib/components/ui/audio/examples/fader-volume-control-demo.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { Fader } from "$lib/components/ui/audio/elements/fader/index.js";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
+
+	const audioStore = getAudioContext();
 
 	function handleVolumeChange(value: number) {
 		audioStore.setVolume({ volume: value / 100 });

--- a/src/lib/components/ui/audio/examples/track-demo.svelte
+++ b/src/lib/components/ui/audio/examples/track-demo.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import * as AudioTrack from "$lib/components/ui/audio/track/index.js";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
+
+	const audioStore = getAudioContext();
 </script>
 
 {#if audioStore.queue[0]}

--- a/src/lib/components/ui/audio/playback-speed/playback-speed.svelte
+++ b/src/lib/components/ui/audio/playback-speed/playback-speed.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { Gauge } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
-	import { htmlAudio } from "$lib/html-audio.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
 	import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button, type ButtonSize, type ButtonVariant } from "$lib/components/ui/button";
+
+	const audioStore = getAudioContext();
 
 	const DEFAULT_SPEEDS = [
 		{ value: 0.5, label: "0.5x" },
@@ -37,7 +38,7 @@
 		...rest
 	}: Props = $props();
 
-	const isLiveStream = $derived(htmlAudio.isLive(audioStore.duration));
+	const isLiveStream = $derived(audioStore.isLive);
 	const currentSpeed = $derived(
 		speeds.find((s) => s.value === audioStore.playbackRate) ?? speeds[2]
 	);

--- a/src/lib/components/ui/audio/player/audio-player-fast-forward.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-fast-forward.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { FastForward } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button, type ButtonSize, type ButtonVariant } from "$lib/components/ui/button";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ui/audio/player/audio-player-fast-forward.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-fast-forward.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { FastForward } from "@lucide/svelte";
 	import { audioStore } from "$lib/audio-store.svelte.js";
-	import { htmlAudio } from "$lib/html-audio.js";
 	import { cn } from "$lib/utils.js";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button, type ButtonSize, type ButtonVariant } from "$lib/components/ui/button";
@@ -22,7 +21,7 @@
 		...rest
 	}: Props = $props();
 
-	const isLiveStream = $derived(htmlAudio.isLive(audioStore.duration));
+	const isLiveStream = $derived(audioStore.isLive);
 	const isDisabled = $derived(() => {
 		if (!audioStore.currentTrack || isLiveStream) return true;
 		return audioStore.duration > 0 && audioStore.currentTime >= audioStore.duration;

--- a/src/lib/components/ui/audio/player/audio-player-play.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-play.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import { Loader2, Pause, Play } from "@lucide/svelte";
 	import { onMount } from "svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button, type ButtonSize, type ButtonVariant } from "$lib/components/ui/button";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ui/audio/player/audio-player-rewind.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-rewind.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { Rewind } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button, type ButtonSize, type ButtonVariant } from "$lib/components/ui/button";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ui/audio/player/audio-player-rewind.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-rewind.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { Rewind } from "@lucide/svelte";
 	import { audioStore } from "$lib/audio-store.svelte.js";
-	import { htmlAudio } from "$lib/html-audio.js";
 	import { cn } from "$lib/utils.js";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button, type ButtonSize, type ButtonVariant } from "$lib/components/ui/button";
@@ -22,7 +21,7 @@
 		...rest
 	}: Props = $props();
 
-	const isLiveStream = $derived(htmlAudio.isLive(audioStore.duration));
+	const isLiveStream = $derived(audioStore.isLive);
 	const isDisabled = $derived(
 		!audioStore.currentTrack || audioStore.currentTime <= 0 || isLiveStream
 	);

--- a/src/lib/components/ui/audio/player/audio-player-seek-bar.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-seek-bar.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
 	import AudioSeekSlider from "./audio-seek-slider.svelte";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ui/audio/player/audio-player-seek-bar.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-seek-bar.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { audioStore } from "$lib/audio-store.svelte.js";
-	import { htmlAudio } from "$lib/html-audio.js";
 	import { cn } from "$lib/utils.js";
 	import AudioSeekSlider from "./audio-seek-slider.svelte";
 
@@ -10,7 +9,7 @@
 
 	let { class: className = "" }: Props = $props();
 
-	const isLiveStream = $derived(htmlAudio.isLive(audioStore.duration));
+	const isLiveStream = $derived(audioStore.isLive);
 
 	const progress = $derived(() => {
 		if (isLiveStream) return 100;

--- a/src/lib/components/ui/audio/player/audio-player-skip-back.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-skip-back.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { SkipBack } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button, type ButtonSize, type ButtonVariant } from "$lib/components/ui/button";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ui/audio/player/audio-player-skip-forward.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-skip-forward.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { SkipForward } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button, type ButtonSize, type ButtonVariant } from "$lib/components/ui/button";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ui/audio/player/audio-player-time-display.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-time-display.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Radio } from "@lucide/svelte";
 	import { audioStore } from "$lib/audio-store.svelte.js";
-	import { htmlAudio, formatDuration } from "$lib/html-audio.js";
+	import { formatDuration } from "$lib/html-audio.js";
 	import { cn } from "$lib/utils.js";
 
 	interface Props {
@@ -12,7 +12,7 @@
 
 	let { remaining = false, class: className = "", ...rest }: Props = $props();
 
-	const isLiveStream = $derived(htmlAudio.isLive(audioStore.duration));
+	const isLiveStream = $derived(audioStore.isLive);
 
 	const formattedCurrentTime = $derived(formatDuration(audioStore.currentTime));
 	const formattedRemaining = $derived(

--- a/src/lib/components/ui/audio/player/audio-player-time-display.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-time-display.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { Radio } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { formatDuration } from "$lib/html-audio.js";
 	import { cn } from "$lib/utils.js";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		remaining?: boolean;

--- a/src/lib/components/ui/audio/player/audio-player-volume.svelte
+++ b/src/lib/components/ui/audio/player/audio-player-volume.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import { Volume, Volume1, Volume2, VolumeX } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
 	import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button, type ButtonSize, type ButtonVariant } from "$lib/components/ui/button";
 	import { Slider } from "$lib/components/ui/slider";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ui/audio/provider/audio-provider.svelte
+++ b/src/lib/components/ui/audio/provider/audio-provider.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import { onMount, untrack } from "svelte";
 	import type { Snippet } from "svelte";
-	import { htmlAudio } from "$lib/html-audio.js";
-	import type { Track } from "$lib/html-audio.js";
-	import { audioStore, calculateNextIndex } from "$lib/audio-store.svelte.js";
+	import { HtmlAudio, type Track } from "$lib/html-audio.js";
+	import { AudioStore, calculateNextIndex, setAudioContext } from "$lib/audio-store.svelte.js";
 
 	interface Props {
 		tracks?: Track[];
@@ -11,6 +10,11 @@
 	}
 
 	let { tracks = [], children }: Props = $props();
+
+	// ─── Create instances & set context ───────────────────────────────────────
+	const htmlAudio = new HtmlAudio();
+	const audioStore = new AudioStore(htmlAudio);
+	setAudioContext(audioStore);
 
 	// ─── Constants ─────────────────────────────────────────────────────────────
 	const MAX_ERROR_RETRIES = 3;
@@ -296,6 +300,7 @@
 		return () => {
 			ctrl.abort();
 			htmlAudio.removeEventListener("bufferUpdate", handleBufferUpdate);
+			htmlAudio.cleanup();
 			if (saveTimeout) {
 				clearTimeout(saveTimeout);
 				saveTimeout = null;

--- a/src/lib/components/ui/audio/provider/audio-provider.svelte
+++ b/src/lib/components/ui/audio/provider/audio-provider.svelte
@@ -6,14 +6,15 @@
 
 	interface Props {
 		tracks?: Track[];
+		storageKey?: string | null;
 		children: Snippet;
 	}
 
-	let { tracks = [], children }: Props = $props();
+	let { tracks = [], storageKey, children }: Props = $props();
 
 	// ─── Create instances & set context ───────────────────────────────────────
 	const htmlAudio = new HtmlAudio();
-	const audioStore = new AudioStore(htmlAudio);
+	const audioStore = new AudioStore(htmlAudio, storageKey);
 	setAudioContext(audioStore);
 
 	// ─── Constants ─────────────────────────────────────────────────────────────

--- a/src/lib/components/ui/audio/queue/audio-queue-preferences.svelte
+++ b/src/lib/components/ui/audio/queue/audio-queue-preferences.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import { SlidersHorizontal } from "@lucide/svelte";
-	import { audioStore, type InsertMode, type RepeatMode } from "$lib/audio-store.svelte.js";
+	import { getAudioContext, type InsertMode, type RepeatMode } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
 	import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button } from "$lib/components/ui/button";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ui/audio/queue/audio-queue-repeat-mode.svelte
+++ b/src/lib/components/ui/audio/queue/audio-queue-repeat-mode.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { Repeat, Repeat1 } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button } from "$lib/components/ui/button";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ui/audio/queue/audio-queue-shuffle.svelte
+++ b/src/lib/components/ui/audio/queue/audio-queue-shuffle.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { Shuffle } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import { cn } from "$lib/utils.js";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button } from "$lib/components/ui/button";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ui/audio/queue/audio-queue.svelte
+++ b/src/lib/components/ui/audio/queue/audio-queue.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import { ListMusic, Search, Trash2 } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import type { Track } from "$lib/html-audio.js";
 	import { cn } from "$lib/utils.js";
 	import { AudioTrackList } from "$lib/components/ui/audio/track/index";
 	import * as Dialog from "$lib/components/ui/dialog";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import { Button } from "$lib/components/ui/button";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		onTrackSelect?: (index: number) => void;

--- a/src/lib/components/ui/audio/track/audio-track-list.svelte
+++ b/src/lib/components/ui/audio/track/audio-track-list.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import { ListMusic } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
 	import type { Track } from "$lib/html-audio.js";
 	import { cn } from "$lib/utils.js";
 	import AudioTrack from "./audio-track.svelte";
 	import { SortableList } from "$lib/components/ui/audio/elements/sortable-list/index.js";
+
+	const audioStore = getAudioContext();
 
 	type Variant = "default" | "grid";
 

--- a/src/lib/components/ui/audio/track/audio-track.svelte
+++ b/src/lib/components/ui/audio/track/audio-track.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { Music, Pause, Play, Radio, X } from "@lucide/svelte";
-	import { audioStore } from "$lib/audio-store.svelte.js";
-	import { htmlAudio, formatDuration, type Track } from "$lib/html-audio.js";
+	import { getAudioContext } from "$lib/audio-store.svelte.js";
+	import { formatDuration, type Track } from "$lib/html-audio.js";
 	import { cn } from "$lib/utils.js";
 	import { SortableDragHandle } from "$lib/components/ui/audio/elements/sortable-list/index.js";
+
+	const audioStore = getAudioContext();
 
 	interface Props {
 		track?: Track;
@@ -46,7 +48,7 @@
 		resolvedTrack?.live === true ||
 			(trackDuration !== undefined &&
 				trackDuration !== null &&
-				htmlAudio.isLive(trackDuration))
+				audioStore.htmlAudio.isLive(trackDuration))
 	);
 
 	const coverImage = $derived(resolvedTrack?.artwork ?? resolvedTrack?.images?.[0]);

--- a/src/lib/html-audio.ts
+++ b/src/lib/html-audio.ts
@@ -29,7 +29,7 @@ type FadeVolumeParams = {
 	duration: number;
 };
 
-class HtmlAudio {
+export class HtmlAudio {
 	private audio: HTMLAudioElement | null = null;
 	private isInitialized = false;
 	private playPromise: Promise<void> | null = null;
@@ -420,8 +420,6 @@ class HtmlAudio {
 		);
 	}
 }
-
-export const htmlAudio = new HtmlAudio();
 
 const MINUTE_IN_SECONDS = 60;
 


### PR DESCRIPTION
## Summary

Replace the global `audioStore` singleton with Svelte 5's `createContext` API, enabling multiple independent audio players on the same page.

Closes: #52 and #57

## Changes

### 1. `isLive` getter on AudioStore
Adds a convenience `isLive` getter to `AudioStore` that checks `htmlAudio.isLive(this.duration)`, reducing boilerplate in consumer components.

### 2. Singleton → Context
- `html-audio.ts`: Exports the `HtmlAudio` class instead of a pre-instantiated singleton.
- `audio-store.svelte.ts`: Uses `createContext<AudioStore>()` to provide `[getAudioContext, setAudioContext]`. The `AudioStore` class now receives an `HtmlAudio` instance via constructor injection.
- `audio-provider.svelte`: Creates `HtmlAudio` and `AudioStore` instances, then calls `setAudioContext(audioStore)` to make it available to descendants.
- All consumer components: Import `getAudioContext` and call it to retrieve the store instead of importing the singleton directly.

### 3. Optional `storageKey` for per-instance persistence
`AudioProvider` accepts a `storageKey` prop:
- `undefined` (default): Uses `"audio:ui:store"` for backward compatibility.
- Custom string: Persists state under that key (enables multiple players with independent persistence).
- `null`: Disables localStorage persistence entirely.

## Motivation

The singleton pattern prevents using multiple independent audio players on the same page. Context-based instantiation gives each `AudioProvider` subtree its own isolated state and audio element.

## Breaking Changes

- Consumers must now access the store via `getAudioContext()` instead of importing `audioStore` directly.
- Components using `htmlAudio` directly must access it via `audioStore.htmlAudio`.
- Requires Svelte 5.40+ (`createContext` API).